### PR TITLE
Add Flatpak manifest

### DIFF
--- a/org.gottcode.focuswriter.json
+++ b/org.gottcode.focuswriter.json
@@ -1,0 +1,31 @@
+{
+	"app-id": "org.gottcode.focuswriter",
+	"runtime": "org.kde.Platform",
+	"runtime-version": "master",
+	"sdk": "org.kde.Sdk",
+	"command": "focuswriter",
+	"rename-icon": "focuswriter",
+	"rename-appdata": "focuswriter",
+	"finish-args":[
+		"--socket=x11",
+		"--share=network"
+	],
+	"modules":[
+		{
+			"name": "focuswriter",
+			"buildsystem": "simple",
+			"sources":[
+				{
+					"type":"git",
+					"url": "git://github.com/gottcode/focuswriter"
+				}
+			],
+			"build-commands": [
+			"find . -type f -name \"focuswriter.desktop\" -execdir rename focuswriter org.gottcode.focuswriter {} \+",
+			"sed -i 's/focuswriter.desktop/org.gottcode.focuswriter.desktop/g' ./focuswriter.pro",
+			"qmake -makefile PREFIX=/app",
+			"make",
+			"make install"]
+		}
+	]
+}


### PR DESCRIPTION
This adds a manifest for creating a cross-distro Flatpak package (http://flatpak.org).

You can test this by installing flatpak and flatpak-builder and then running

flatpak remote-add kde --from https://distribute.kde.org/kderuntime.flatpakrepo
flatpak install kde org.kde.Platform
flatpak install kde org.kde.Sdk
flatpak-builder --repo=test focuswriter org.gottcode.focuswriter.json
flatpak remote-add --no-gpg-verify test
flatpak install test org.gottcode.focuswriter
flatpak run org.gottcode.focuswriter