### PR TITLE
alphabetize language list in credits

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -11,6 +11,11 @@ Arabic:
 Catalan:
 * Joan Queralt Gil
 
+Chinese (China):
+* Dianjin Wang
+* Jiajun Liu
+* 勇 郭
+
 Czech:
 * Pavel Fric
 * Ladislav Thon
@@ -24,14 +29,6 @@ Dutch:
 Esperanto:
 * Synteq
 
-German:
-* Dennis Peteranderl
-* Eduard Bruckner
-
-Greek:
-* Γιάννης Ανθυμίδης
-* Epameinondas Soufleros
-
 Finnish:
 * Aarni
 * Lasse Liehu
@@ -39,6 +36,14 @@ Finnish:
 French:
 * Guillaume Gay
 * Jérôme Borme
+
+German:
+* Dennis Peteranderl
+* Eduard Bruckner
+
+Greek:
+* Γιάννης Ανθυμίδης
+* Epameinondas Soufleros
 
 Hebrew:
 * Jacob Paikin
@@ -107,11 +112,6 @@ Ukrainian:
 
 Vietnamese:
 * Anh Phan (vi)
-
-Chinese (China):
-* Dianjin Wang
-* Jiajun Liu
-* 勇 郭
 
 
 Icons


### PR DESCRIPTION
I was idly scanning the ReadMe.txt to see if there was a French translation... but the list of languages in (seemingly) alpha order jumped straight from Esperanto to German.

Then I realized that the list was only *mostly* alphabetical: a few languages were out of sequence.

This PR fixes alphabetization only (no content changes at all).

Thanks for the project!