### PR TITLE
mac: create .lproj translations

### DIFF
--- a/mac_deploy.sh
+++ b/mac_deploy.sh
@@ -45,6 +45,15 @@ mkdir "$TRANSLATIONS"
 cp translations/*.qm "$TRANSLATIONS"
 echo 'Done'
 
+# Make macos aware that the app bundle is translated.
+# This is required to translate parts of native open/save dialogs.
+echo -n "Creating mac lproj directories for translations ..."
+for translation in $(find translations -type f -name "*.qm" -print0 | xargs -0); do
+    translation=$(sed 's/translations\/focuswriter_//g' <<< "$translation")
+    translation=$(sed 's/qm/lproj/g' <<< "$translation")
+    mkdir -p "$APP/$BUNDLE/Contents/Resources/$translation"
+done
+
 # Copy Qt translations
 echo -n 'Copying Qt translations... '
 cp $QTDIR/translations/qt_* "$TRANSLATIONS"


### PR DESCRIPTION
Hi @gottcode.

Somehow qt apps fail to translate certain parts of the native cocoa dialogs on osx. The only workaround I know to fix that is to create *empty* `lproj` directories inside the Resources dir within the application bundle. It needs one dir per language, following ISO 639-1 locale names.

This hack iterates over supported focuswriter translations and creates one dir for each of them.

## before
![current](https://user-images.githubusercontent.com/975883/102404932-ae0d4580-3fe8-11eb-8fe3-04bb65ce7499.png)


## after
![translated](https://user-images.githubusercontent.com/975883/102404941-b1083600-3fe8-11eb-8e27-e1e97ef12289.png)
