### PR TITLE
Daily progress color even if upper than goal

### DIFF
--- a/src/daily_progress_dialog.cpp
+++ b/src/daily_progress_dialog.cpp
@@ -71,7 +71,7 @@ public:
 			int progress = qBound(0, index.data(Qt::UserRole).toInt(), 100);
 			if (progress == 0) {
 				opt.backgroundBrush = opt.palette.alternateBase();
-			} else if (progress == 100) {
+			} else if (progress >= 100) {
 				const qreal pixelratio = painter->device()->devicePixelRatioF();
 				painter->drawPixmap(QPointF(opt.rect.topLeft()), fetchStarBackground(opt, pixelratio));
 				opt.font.setBold(true);


### PR DESCRIPTION
It's very quickfix for correct daily progress issue, when daily progress was over than 100% color didn't appear.