### PR TITLE
update german translation and remove shortcut conflict on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 Makefile
 build
 focuswriter
+focuswriter.app
+focuswriter_autogen
 *.qm
 *~
+.qt
+CMakeCache.txt
+CMakeFiles
+cmake_install.cmake
+resources/symbols/generate
+resources/symbols/generate_autogen

--- a/translations/focuswriter_de.ts
+++ b/translations/focuswriter_de.ts
@@ -412,7 +412,7 @@
     </message>
     <message>
         <source>One or more shortcuts conflict. Do you wish to proceed?</source>
-        <translation>Eine oder mehrere Verknüpfungen verursachen Konflikte. Möchten Sie fortfahren?</translation>
+        <translation>Ein oder mehrere Tastaturkurzbefehle (Shortcuts) verursachen Konflikte. Möchten Sie fortfahren?</translation>
     </message>
     <message>
         <source>The dictionary &quot;%1&quot; already exists. Do you want to replace it?</source>
@@ -1575,7 +1575,7 @@
     </message>
     <message>
         <source>Ctrl+K</source>
-        <translation>Strg+G</translation>
+        <translation>Strg+L</translation>
     </message>
     <message>
         <source>Sup&amp;erscript</source>

--- a/translations/focuswriter_de.ts
+++ b/translations/focuswriter_de.ts
@@ -70,11 +70,11 @@
     </message>
     <message>
         <source>Longest streak</source>
-        <translation>Längster Siegeszug</translation>
+        <translation>Längste Erfolgsserie</translation>
     </message>
     <message>
         <source>Current streak</source>
-        <translation>Aktueller Siegeszug</translation>
+        <translation>Aktuelle Erfolgsserie</translation>
     </message>
     <message>
         <source>N/A</source>
@@ -408,11 +408,11 @@
     </message>
     <message>
         <source>Shortcuts</source>
-        <translation>Shortcuts</translation>
+        <translation>Tastaturkurzbefehle</translation>
     </message>
     <message>
         <source>One or more shortcuts conflict. Do you wish to proceed?</source>
-        <translation>Ein oder mehrere Tastaturkurzbefehle (Shortcuts) verursachen Konflikte. Möchten Sie fortfahren?</translation>
+        <translation>Ein oder mehrere Tastaturkurzbefehle wurden doppelt belegt. Möchten Sie fortfahren?</translation>
     </message>
     <message>
         <source>The dictionary &quot;%1&quot; already exists. Do you want to replace it?</source>
@@ -536,11 +536,11 @@
     </message>
     <message>
         <source>Show streaks</source>
-        <translation>Siegeszüge anzeigen</translation>
+        <translation>Erfolgsserie anzeigen</translation>
     </message>
     <message>
         <source>Minimum progress for streaks:</source>
-        <translation>Mindestfortschritt für Siegeszüge:</translation>
+        <translation>Mindestfortschritt für Erfolgsserie:</translation>
     </message>
     <message>
         <source>Detect word boundaries</source>
@@ -572,7 +572,7 @@
     </message>
     <message>
         <source>Text Alongside Icons</source>
-        <translation>Text neben  Symbolen</translation>
+        <translation>Text neben Symbolen</translation>
     </message>
     <message>
         <source>Text Under Icons</source>
@@ -604,7 +604,7 @@
     </message>
     <message>
         <source>Shortcut</source>
-        <translation>Shortcut</translation>
+        <translation>Tastaturkurzbefehle</translation>
     </message>
     <message>
         <source>Action</source>
@@ -783,7 +783,7 @@
     </message>
     <message>
         <source>The requested session name is already in use.</source>
-        <translation>Die gewünschte Sitzung wird derzeit benutzt.</translation>
+        <translation>Der gewählte Name für die Sitzung wird bereits verwendet.</translation>
     </message>
     <message>
         <source>&amp;New...</source>
@@ -814,7 +814,7 @@
     </message>
     <message>
         <source>Shortcut:</source>
-        <translation>Shortcut:</translation>
+        <translation>Tastaturkurzbefehl:</translation>
     </message>
 </context>
 <context>
@@ -1179,7 +1179,7 @@
     </message>
     <message>
         <source>Bitter Skies</source>
-        <translation>Bittere Himmel</translation>
+        <translation>Bedrückender Himmel</translation>
     </message>
     <message>
         <source>Enchantment</source>
@@ -1383,23 +1383,23 @@
     </message>
     <message>
         <source>Switch to Next Document</source>
-        <translation>Ins nächste Dokument übergehen</translation>
+        <translation>Zum nächsten Dokument wechseln</translation>
     </message>
     <message>
         <source>Switch to Previous Document</source>
-        <translation>Ins vorherige Dokument übergehen</translation>
+        <translation>Zum vorherigen Dokument wechseln</translation>
     </message>
     <message>
         <source>Switch to First Document</source>
-        <translation>Ins erste Dokument übergehen</translation>
+        <translation>Zum ersten Dokument wechseln</translation>
     </message>
     <message>
         <source>Switch to Last Document</source>
-        <translation>Ins letzte Dokument übergehen</translation>
+        <translation>Zum letzten Dokument wechseln</translation>
     </message>
     <message>
         <source>Switch to Document %1</source>
-        <translation>Ins Dokument %1 übergehen</translation>
+        <translation>Zu Dokument %1 wechseln</translation>
     </message>
     <message>
         <source>Loading settings</source>


### PR DESCRIPTION
### Issue 1:
German translation for wrong shortcuts is confusing for a German. I needed to look into to source-code first to understand what this message means without knowing more context.

     <message>
           <source>One or more shortcuts conflict. Do you wish to proceed?</source>
           <translation>Eine oder mehrere **Verknüpfungen** verursachen Konflikte. Möchten Sie fortfahren?</translation>
       </message>

**Verknüpfungen** is used for _links in internet_ or for _links between files_ but is not associated with keyboard shortcuts. This would be **Tastaturkurzbefehl** (or even Shortcuts without translation since some Germans are already familiar with this).

I would translate it to this here to avoid miss-understandings. 

     <message>
           <source>One or more shortcuts conflict. Do you wish to proceed?</source>
           <translation>Ein oder mehrere **Tastaturkurzbefehle(Shortcuts)** verursachen Konflikte. Möchten Sie fortfahren?</translation>
       </message>


### Issue 2:
There is a shortcut error directly after first start of the program without any user change when using the program on macOS in Germany.

**QKeySequence::FindNext** is **Crtl+G** on macOS (!), see on https://doc.qt.io/qtforpython-5/PySide2/QtGui/QKeySequence.html .

StandardKey 	Windows 	macOS 	KDE Plasma 	GNOME

**FindNext**	F3, Ctrl+G	**Ctrl+G**	F3		Ctrl+G, F3
...
DeleteEndOfLine	(none)		(none)	Ctrl+K		Ctrl+K


`format_menu->addAction(QIcon::fromTheme("format-text-strikethrough"), tr("Stri&kethrough"), m_documents, &Stack::setFontStrikeOut, tr("Ctrl+K"));`


tr("Ctrl+K") Ctrl+K is in german translated as **Ctrl+G** that is on macOS already used as QKeySequence::FindNext. 

    <message>
           <source>Ctrl+K</source>
           <translation>**Strg+G**</translation>
       </message>

The translator probably was going to avoid a conflict with QKeySequence::DeleteEndOfLine on KDE/GNOME but with this translation caused a conflict on macOS.

Solution would be to translate "Ctrl+K" to a shortcut that is not already used by any of the Qt default shortcuts for any system and also not already used by focusWriter itself. **Ctrl+L** seems to satisfy both conditions.

### Issue 3:
I also updated .gitignore since the folder looked so messy after the build on macOS and git found dozens of new files it recommended for adding.

### Issue 4:
Finally I decided to review the complete German translation as a native speaker. All in all it was not so bad, but sill I changed some sentences and words here and there. Also decided to better replace all mentionings of shortcuts finally by "Tastaturkurzbefehle".