### PR TITLE
Add DICPATH to dictionary search path on unix systems

### DIFF
--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -101,6 +101,13 @@ void Paths::load(const QString& appdir, QString& userdir, const QString& datadir
 #endif
 	});
 
+#ifdef Q_OS_UNIX
+	QStringList dicpath = QString::fromLocal8Bit(qgetenv("DICPATH")).split(":", Qt::SkipEmptyParts);
+	for (auto it = dicpath.rbegin(); it != dicpath.rend(); ++it) {
+		QDir::addSearchPath("dict", *it);
+	}
+#endif
+
 	// Set location for daily progress
 	DailyProgress::setPath(dir.absoluteFilePath("DailyProgress.ini"));
 }


### PR DESCRIPTION
Hunspell supports the `DICPATH` environmental variable to support different paths for dictionary files, see for example
https://github.com/hunspell/hunspell/issues/413

However, focuswriter does not check those paths in the "Set Language" dialog (so for me the list was empty and I could not spellcheck at all). It would be nice to get that supported.

As mentioned in the linked issue this is probably mostly relevant for more exotic package managers such as Nix, as is the case for me. If this PR is too specific I will try to fix the issue further downstream.