### PR TITLE
Fix compile error with QString::arg and char32_t on newer Clang

### DIFF
--- a/src/symbols_dialog.cpp
+++ b/src/symbols_dialog.cpp
@@ -377,7 +377,7 @@ void SymbolsDialog::symbolClicked(const QModelIndex& symbol)
 		m_symbol_preview->setSceneRect(m_symbol_preview_item->boundingRect());
 		m_symbol_name->setText(name);
 		m_symbol_name->setToolTip(name);
-		m_symbol_code->setText(QString("<tt>U+%1</tt>").arg(unicode, 4, 16, QLatin1Char('0')).toUpper());
+		m_symbol_code->setText(QString("<tt>U+%1</tt>").arg(static_cast<quint32>(unicode), 4, 16, QLatin1Char('0')).toUpper());
 		m_symbol_shortcut->setShortcut(ActionManager::instance()->shortcut(unicode));
 
 		// Select symbol in recent list, and clear any other selections


### PR DESCRIPTION
Fix: Compile error on Clang 17 / Qt 5.15+
This PR fixes an issue with QString::arg where passing a char32_t causes a template deduction failure on newer compilers (Clang 17 with Xcode 15+).
The fix casts the unicode value to quint32, which is supported by the relevant QString::arg() overload. This maintains compatibility across platforms and Qt versions.