### PR TITLE
Add script for installing dependencies

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -4,6 +4,8 @@ Installation
 Open a terminal and browse into the extracted folder.
 
 Linux:
+  0. Install dependencies. On Ubuntu and Debian this can be done with ./scripts/install-dependencies-debian-ubuntu.sh
+
   1. `cmake -B build -S . -DCMAKE_INSTALL_PREFIX=/usr' to create a location
      for the build and then configure the program. There are more options
      you can pass to CMake, see below for details.

--- a/scripts/install-dependencies-debian-ubuntu.sh
+++ b/scripts/install-dependencies-debian-ubuntu.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo apt-get install qt6-tools-dev qt6-multimedia-dev libhunspell-dev gettext qt6-l10n-tools qt6-tools-dev-tools gettext cmake build-essential
+


### PR DESCRIPTION
I wanted to compile FocusWriter myself, so I can add my own code and also have the latest version. 

It was quiet challenging to know which libraries I needed to install in order to compile it following the "INSTALL" document. After spending 30 minutes to figure it out, I added a script for installing the dependencies for Ubuntu and Debian in `scripts/install-dependencies-debian-ubuntu.sh`, so other people can have an easier time.

Installation scripts for other platforms can be added later by users of those platforms