### PR TITLE
Add keyboard shortcuts for headings

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1358,6 +1358,7 @@ void Window::initMenus()
 	for (int i = 0; i < 7; ++i) {
 		headings[i]->setCheckable(true);
 		headings[i]->setData(i);
+		headings[i]->setShortcut(QKeySequence(Qt::CTRL | Qt::ALT | (Qt::Key_0 + i)));
 		m_headings_actions->addAction(headings[i]);
 		connect(headings[i], &QAction::triggered, this, [this, i] { m_documents->setBlockHeading(i); });
 	}


### PR DESCRIPTION
Most rich-text editors let the user set the Heading level with Ctrl+Alt+[heading number], e.g. Ctrl+Alt+2 for Heading level 2.

Ctrl+Alt+0 is often used for normal text.

This PR makes FocusWriter support these common keyboard shortcuts.

### Sources:
Keyboard shortcuts used in Word
https://daisy.org/guidance/info-help/guidance-training/content-creation/applying-headings-in-microsoft-word/

Keyboard shortcuts used in Google Docs
https://support.google.com/docs/answer/179738?hl=en&co=GENIE.Platform%3DDesktop#zippy=%2Cpc-shortcuts
