### PR TITLE
Use better quality Finnish spell checking if it is available.

### DIFF
--- a/src/spelling/dictionary_manager.cpp
+++ b/src/spelling/dictionary_manager.cpp
@@ -143,11 +143,11 @@ void DictionaryManager::addProviders()
 		}
 	}
 
-	if (!has_hunspell) {
-		addProvider(new DictionaryProviderHunspell);
-	}
 	if (!has_voikko) {
 		addProvider(new DictionaryProviderVoikko);
+	}
+	if (!has_hunspell) {
+		addProvider(new DictionaryProviderHunspell);
 	}
 #else
 	bool has_nsspellchecker = false;


### PR DESCRIPTION
Many Finns end up installing `hunspell` along `voikko` because of poor spell checking support in some software...
(Firefox!)

By trying to use `voikko` before `hunspell` a better Finnish language spell checking is guaranteed when it is available.