### PR TITLE
Add Markdown support, using Qts build in functionallity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,8 @@ qt_add_executable(focuswriter
 	src/fileformats/docx_writer.h
 	src/fileformats/format_manager.h
 	src/fileformats/html_writer.h
+	src/fileformats/md_reader.h
+	src/fileformats/md_writer.h
 	src/fileformats/odt_reader.h
 	src/fileformats/odt_writer.h
 	src/fileformats/rtf_reader.h
@@ -150,6 +152,8 @@ qt_add_executable(focuswriter
 	src/fileformats/docx_writer.cpp
 	src/fileformats/format_manager.cpp
 	src/fileformats/html_writer.cpp
+	src/fileformats/md_reader.cpp
+	src/fileformats/md_writer.cpp
 	src/fileformats/odt_reader.cpp
 	src/fileformats/odt_writer.cpp
 	src/fileformats/rtf_reader.cpp

--- a/src/document_writer.cpp
+++ b/src/document_writer.cpp
@@ -7,6 +7,7 @@
 #include "document_writer.h"
 
 #include "docx_writer.h"
+#include "md_writer.h"
 #include "odt_writer.h"
 #include "rtf_writer.h"
 
@@ -67,6 +68,10 @@ bool DocumentWriter::write()
 	} else if (m_type == "rtf") {
 		file.setTextModeEnabled(true);
 		RtfWriter writer;
+		saved = writer.write(&file, m_document);
+	} else if (m_type == "md" || m_type == "markdown") {
+		file.setTextModeEnabled(true);
+		MdWriter writer;
 		saved = writer.write(&file, m_document);
 	} else {
 		file.setTextModeEnabled(true);

--- a/src/fileformats/format_manager.cpp
+++ b/src/fileformats/format_manager.cpp
@@ -7,6 +7,7 @@
 #include "format_manager.h"
 
 #include "docx_reader.h"
+#include "md_reader.h"
 #include "odt_reader.h"
 #include "rtf_reader.h"
 #include "txt_reader.h"
@@ -30,6 +31,8 @@ FormatReader* FormatManager::createReader(QIODevice* device, const QString& type
 		if (RtfReader::canRead(device)) {
 			reader = new RtfReader;
 		}
+	} else if (type == "md" || type == "markdown") {
+		reader = new MdReader;
 	}
 
 	// Fall back to finding format from contents
@@ -62,6 +65,8 @@ QString FormatManager::filter(const QString& type)
 		return tr("Rich Text Format") + QLatin1String(" (*.rtf)");
 	} else if ((type == "txt") || (type == "text")) {
 		return tr("Plain Text") + QLatin1String(" (*.txt *.text)");
+	} else if ((type == "md") || (type == "markdown")) {
+		return tr("Markdown") + QLatin1String(" (*.md *.markdown)");
 	} else {
 		return QString();
 	}
@@ -77,6 +82,7 @@ QStringList FormatManager::filters(const QString& type)
 		filter("docx"),
 		filter("rtf"),
 		filter("txt"),
+		filter("md"),
 		(tr("All Files") + QLatin1String(" (*)"))
 	};
 
@@ -90,11 +96,13 @@ QStringList FormatManager::filters(const QString& type)
 			result.move(3, 0);
 		} else if ((type == "txt") || (type == "text")) {
 			result.move(4, 0);
-		} else if (type != "odt") {
+		} else if ((type == "md") || (type == "markdown")) {
 			result.move(5, 0);
+		} else if (type != "odt") {
+			result.move(6, 0);
 		}
 	} else {
-		result.prepend(tr("All Supported Files") + QLatin1String(" (*.docx *.fodt *.odt *.rtf *.txt *.text)"));
+		result.prepend(tr("All Supported Files") + QLatin1String(" (*.docx *.fodt *.md *.markdown *.odt *.rtf *.txt *.text)"));
 	}
 	return result;
 }
@@ -104,14 +112,14 @@ QStringList FormatManager::filters(const QString& type)
 bool FormatManager::isRichText(const QString& filename)
 {
 	const QString type = filename.section(QLatin1Char('.'), -1).toLower();
-	return (type == "odt") || (type == "fodt") || (type == "docx") || (type == "rtf");
+	return (type == "odt") || (type == "fodt") || (type == "docx") || (type == "rtf") || (type == "md") || (type == "markdown");
 }
 
 //-----------------------------------------------------------------------------
 
 QStringList FormatManager::types()
 {
-	static const QStringList types{ "odt", "fodt", "docx", "rtf", "txt" };
+	static const QStringList types{ "odt", "fodt", "docx", "rtf", "txt", "md" };
 	return types;
 }
 

--- a/src/fileformats/md_reader.cpp
+++ b/src/fileformats/md_reader.cpp
@@ -1,0 +1,26 @@
+/*
+	SPDX-FileCopyrightText: 2024 Graeme Gott <graeme@gottcode.org>
+
+	SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "md_reader.h"
+
+#include <QTextDocument>
+#include <QTextStream>
+
+//-----------------------------------------------------------------------------
+
+MdReader::MdReader()
+{
+}
+
+//-----------------------------------------------------------------------------
+
+void MdReader::readData(QIODevice* device)
+{
+	QTextStream stream(device);
+	m_cursor.document()->setMarkdown(stream.readAll(), QTextDocument::MarkdownDialectGitHub);
+}
+
+//-----------------------------------------------------------------------------

--- a/src/fileformats/md_reader.h
+++ b/src/fileformats/md_reader.h
@@ -1,0 +1,27 @@
+/*
+	SPDX-FileCopyrightText: 2024 Graeme Gott <graeme@gottcode.org>
+
+	SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef FOCUSWRITER_MD_READER_H
+#define FOCUSWRITER_MD_READER_H
+
+#include "format_reader.h"
+
+class MdReader : public FormatReader
+{
+public:
+	explicit MdReader();
+
+	enum { Type = 5 };
+	int type() const override
+	{
+		return Type;
+	}
+
+private:
+	void readData(QIODevice* device) override;
+};
+
+#endif // FOCUSWRITER_MD_READER_H

--- a/src/fileformats/md_writer.cpp
+++ b/src/fileformats/md_writer.cpp
@@ -1,0 +1,21 @@
+/*
+	SPDX-FileCopyrightText: 2024 Graeme Gott <graeme@gottcode.org>
+
+	SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "md_writer.h"
+
+#include <QTextDocument>
+#include <QTextStream>
+
+//-----------------------------------------------------------------------------
+
+bool MdWriter::write(QIODevice* device, const QTextDocument* document)
+{
+	QTextStream stream(device);
+	stream << document->toMarkdown(QTextDocument::MarkdownDialectGitHub);
+	return stream.status() == QTextStream::Ok;
+}
+
+//-----------------------------------------------------------------------------

--- a/src/fileformats/md_writer.h
+++ b/src/fileformats/md_writer.h
@@ -1,0 +1,28 @@
+/*
+	SPDX-FileCopyrightText: 2024 Graeme Gott <graeme@gottcode.org>
+
+	SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef FOCUSWRITER_MD_WRITER_H
+#define FOCUSWRITER_MD_WRITER_H
+
+#include <QString>
+class QIODevice;
+class QTextDocument;
+
+class MdWriter
+{
+public:
+	QString errorString() const
+	{
+		return m_error;
+	}
+
+	bool write(QIODevice* device, const QTextDocument* document);
+
+private:
+	QString m_error;
+};
+
+#endif // FOCUSWRITER_MD_WRITER_H


### PR DESCRIPTION
Add Markdown (.md / .markdown) read and write support

Uses Qt's built-in [toMarkdown](https://doc.qt.io/qt-6/qtextdocument.html#toMarkdown) preserving headings, bold, italic, strikethrough and blockquotes.

A good way to try out the support is opening README.md on other github projects, like for example  <https://github.com/albertz/openlierox/>, <https://github.com/stochsd/stochsd> (examples are chosen based on projects I worked on)
