### PR TITLE
Fix macOS packaging with Homebrew Qt on Apple Silicon

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -20,14 +20,18 @@ Linux:
      'alternate/directory' before all installation names.
 
 macOS:
-  1. `cmake -B build -S .' to create a location for the build and then
+  1. Install Qt 6 if it is not already available. With Homebrew this is
+     typically `brew install qt'.
+
+  2. `cmake -B build -S .' to create a location for the build and then
      configure the program. There are more options you can pass to CMake,
      see below for details.
 
-  2. `cmake --build build' to compile the program.
+  3. `cmake --build build' to compile the program.
 
-  3. Run `mac_deploy.sh' from inside the build directory to create a disk
-     image of the program.
+  4. Run `mac_deploy.sh' from inside the build directory to create a disk
+     image of the program. The script automatically detects Qt tools and
+     translations from a Homebrew Qt installation.
 
 Windows:
   1. `cmake -B ..\build -S .' to create a location for the build and then

--- a/mac_deploy.sh
+++ b/mac_deploy.sh
@@ -1,12 +1,64 @@
 #!/bin/bash
 
+set -euo pipefail
+
 APP='FocusWriter'
 BUNDLE="$APP.app"
 VERSION='1.9.0'
 
+find_qt_tool() {
+	local tool
+	for tool in "$@"; do
+		if command -v "$tool" >/dev/null 2>&1; then
+			command -v "$tool"
+			return 0
+		elif [ -n "${QTDIR:-}" ] && [ -x "${QTDIR}/bin/${tool}" ]; then
+			printf '%s\n' "${QTDIR}/bin/${tool}"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+copy_qt_plugin() {
+	local plugin="$1"
+	local source="${QT_PLUGINS}/${plugin}"
+	local target="${APP}/${BUNDLE}/Contents/PlugIns/${plugin}"
+
+	if [ ! -f "$source" ]; then
+		echo "Missing Qt plugin: $source" >&2
+		exit 1
+	fi
+
+	mkdir -p "$(dirname "$target")"
+	cp "$source" "$target"
+	DEPLOY_EXECUTABLES+=("-executable=${SCRIPT_DIR}/${target}")
+}
+
 # Locate deployment script
 BIN_DIR=$(pwd)
-cd $(dirname "${BASH_SOURCE[0]}")
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+QTPATHS_BIN=$(find_qt_tool qtpaths qtpaths6) || {
+	echo 'Unable to find qtpaths. Install Qt 6 and ensure its tools are in PATH or set QTDIR.' >&2
+	exit 1
+}
+
+QT_PREFIX=$("$QTPATHS_BIN" --query QT_INSTALL_PREFIX)
+QT_LIBS=$("$QTPATHS_BIN" --query QT_INSTALL_LIBS)
+QT_PLUGINS=$("$QTPATHS_BIN" --query QT_INSTALL_PLUGINS)
+QT_TRANSLATIONS=$("$QTPATHS_BIN" --query QT_INSTALL_TRANSLATIONS)
+
+MACDEPLOYQT_BIN=$(find_qt_tool macdeployqt macdeployqt6 || true)
+if [ -z "$MACDEPLOYQT_BIN" ] && [ -x "${QT_PREFIX}/bin/macdeployqt" ]; then
+	MACDEPLOYQT_BIN="${QT_PREFIX}/bin/macdeployqt"
+fi
+if [ -z "$MACDEPLOYQT_BIN" ]; then
+	echo 'Unable to find macdeployqt. Install Qt 6 and ensure its tools are in PATH or set QTDIR.' >&2
+	exit 1
+fi
 
 # Remove any previous disk folder or DMG
 echo -n 'Preparing... '
@@ -45,15 +97,27 @@ echo 'Done'
 # Copy Qt translations
 echo -n 'Copying Qt translations... '
 TRANSLATIONS="$APP/$BUNDLE/Contents/Resources/translations"
-cp $QTDIR/translations/qt_* "$TRANSLATIONS"
-cp $QTDIR/translations/qtbase_* "$TRANSLATIONS"
-rm -f $TRANSLATIONS/qt_help_*
+mkdir -p "$TRANSLATIONS"
+find "$QT_TRANSLATIONS" -maxdepth 1 -type f \( -name 'qt_*.qm' -o -name 'qtbase_*.qm' \) ! -name 'qt_help_*' -exec cp {} "$TRANSLATIONS" \;
 echo 'Done'
 
 # Copy frameworks and plugins
 echo -n 'Copying frameworks and plugins... '
-macdeployqt "$APP/$BUNDLE"
-rm -Rf "$APP/$BUNDLE/Contents/PlugIns/iconengines"
+DEPLOY_EXECUTABLES=()
+DEPLOY_ARGS=(
+	"-no-plugins"
+	"-libpath=${QT_LIBS}"
+)
+if [ -d "${QT_PREFIX}/Frameworks" ]; then
+	DEPLOY_ARGS+=("-libpath=${QT_PREFIX}/Frameworks")
+fi
+
+# Deploy only the plugins the app actually needs on macOS.
+copy_qt_plugin 'platforms/libqcocoa.dylib'
+copy_qt_plugin 'styles/libqmacstyle.dylib'
+copy_qt_plugin 'imageformats/libqjpeg.dylib'
+
+"$MACDEPLOYQT_BIN" "${SCRIPT_DIR}/${APP}/${BUNDLE}" "${DEPLOY_ARGS[@]}" "${DEPLOY_EXECUTABLES[@]}"
 echo 'Done'
 
 # Copy background


### PR DESCRIPTION
This fixes the macOS packaging flow for Apple Silicon/Homebrew Qt installs.

  What changed:
  - detect Qt tools and install paths with `qtpaths` instead of relying on `QTDIR`
  - copy Qt translations from the discovered Qt installation
  - make `mac_deploy.sh` fail fast if required Qt tools or plugins are missing
  - deploy only the macOS plugins FocusWriter actually needs (`libqcocoa`, `libqmacstyle`, `libqjpeg`)
  - update the macOS install instructions to mention the Homebrew Qt workflow

  Why this is needed:
  - the app itself builds on Apple Silicon once Qt 6 is installed
  - the old deploy script assumes `QTDIR/translations` exists and lets `macdeployqt` sweep optional Homebrew Qt plugins
  - on my Apple Silicon/Homebrew setup that produced a broken DMG, with unresolved `QtPdf`, `QtSvg`, and `QtVirtualKeyboard` plugin dependencies during deployment

  Verification:
  - `brew install qt`
  - `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
  - `cmake --build build -j8`
  - run `../mac_deploy.sh` from the `build` directory
  - verified the generated DMG mounts correctly
  - verified `FocusWriter.app` inside the DMG passes `codesign --verify --deep --strict`

  Tested on:
  - Apple Silicon Mac
  - Homebrew Qt 6

Please find the resulting .dmg [here](https://drive.google.com/file/d/1j5NB5zZOo5mlRQ5QLZ_PtF-_6B_K5eeo/view?usp=sharing) for testing