### PR TITLE
Optionally display word count in themes

### DIFF
--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -217,7 +217,7 @@ void Stack::setMargins(int footer, int header)
 	updateMargin();
 	updateBackground();
 	updateMask();
-	m_top_wordcount->move(15, m_header_visible + 10);
+	positionWordCount();
 	showHeader();
 }
 
@@ -570,9 +570,9 @@ void Stack::themeSelected(const Theme& theme)
 	updateBackground();
 
 	m_top_wordcount->setVisible(m_theme.showWordCount());
-	m_top_wordcount->setFont(m_theme.textFont());
+	m_top_wordcount->setFont(m_theme.wordcountFont());
 	QPalette p = m_top_wordcount->palette();
-	p.setColor(QPalette::WindowText, m_theme.textColor());
+	p.setColor(QPalette::WindowText, m_theme.wordcountColor());
 	m_top_wordcount->setPalette(p);
 	updateWordCount();
 
@@ -614,6 +614,7 @@ void Stack::setFooterVisible(bool visible)
 		Q_EMIT footerVisible(visible);
 		m_footer_visible = footer_visible;
 		updateMask();
+		positionWordCount();
 	}
 }
 
@@ -627,7 +628,7 @@ void Stack::setHeaderVisible(bool visible)
 		Q_EMIT headerVisible(visible);
 		m_header_visible = header_visible;
 		updateMask();
-		m_top_wordcount->move(15, m_header_visible + 10);
+		positionWordCount();
 	}
 }
 
@@ -688,7 +689,7 @@ void Stack::resizeEvent(QResizeEvent* event)
 	updateMask();
 	m_resize_timer->start();
 	updateBackground();
-	m_top_wordcount->move(15, m_header_visible + 10);
+	positionWordCount();
 	QWidget::resizeEvent(event);
 }
 
@@ -840,7 +841,38 @@ void Stack::updateWordCount()
 	} else {
 		m_top_wordcount->setText(tr("Words: %L1").arg(0));
 	}
+	positionWordCount();
+}
+
+//-----------------------------------------------------------------------------
+
+void Stack::positionWordCount()
+{
 	m_top_wordcount->adjustSize();
+
+	int x = 15;
+	int y = 10;
+
+	switch (m_theme.wordcountPosition()) {
+	case 0: // Top Left
+		x = 15;
+		y = m_header_visible + 10;
+		break;
+	case 1: // Top Right
+		x = width() - 15 - m_top_wordcount->width();
+		y = m_header_visible + 10;
+		break;
+	case 2: // Bottom Left
+		x = 15;
+		y = height() + m_footer_visible - 10 - m_top_wordcount->height();
+		break;
+	case 3: // Bottom Right
+		x = width() - 15 - m_top_wordcount->width();
+		y = height() + m_footer_visible - 10 - m_top_wordcount->height();
+		break;
+	}
+
+	m_top_wordcount->move(x, y);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -24,6 +24,7 @@
 #include <QClipboard>
 #include <QDir>
 #include <QGridLayout>
+#include <QLabel>
 #include <QMenu>
 #include <QMessageBox>
 #include <QPageSetupDialog>
@@ -96,6 +97,9 @@ Stack::Stack(QWidget* parent)
 	setHeaderVisible(Preferences::instance().alwaysShowHeader());
 	setFooterVisible(Preferences::instance().alwaysShowFooter());
 
+	m_top_wordcount = new QLabel(this);
+	m_top_wordcount->setVisible(false);
+
 	// Always draw background
 	setAttribute(Qt::WA_OpaquePaintEvent);
 	setAutoFillBackground(false);
@@ -126,6 +130,7 @@ void Stack::addDocument(Document* document)
 	connect(document->text(), &QTextEdit::redoAvailable, this, &Stack::redoAvailable);
 	connect(document->text(), &QTextEdit::undoAvailable, this, &Stack::undoAvailable);
 	connect(document->text(), &QTextEdit::currentCharFormatChanged, this, &Stack::updateFormatActions);
+	connect(document, &Document::changed, this, qOverload<>(&Stack::updateWordCount));
 
 	m_documents.append(document);
 	m_contents->addWidget(document);
@@ -197,6 +202,8 @@ void Stack::setCurrentDocument(int index)
 	Q_EMIT redoAvailable(m_current_document->text()->document()->isRedoAvailable());
 	Q_EMIT undoAvailable(m_current_document->text()->document()->isUndoAvailable());
 	Q_EMIT updateFormatActions();
+
+	updateWordCount();
 }
 
 //-----------------------------------------------------------------------------
@@ -210,6 +217,7 @@ void Stack::setMargins(int footer, int header)
 	updateMargin();
 	updateBackground();
 	updateMask();
+	m_top_wordcount->move(15, m_header_visible + 10);
 	showHeader();
 }
 
@@ -561,6 +569,13 @@ void Stack::themeSelected(const Theme& theme)
 	updateMargin();
 	updateBackground();
 
+	m_top_wordcount->setVisible(m_theme.showWordCount());
+	m_top_wordcount->setFont(m_theme.textFont());
+	QPalette p = m_top_wordcount->palette();
+	p.setColor(QPalette::WindowText, m_theme.textColor());
+	m_top_wordcount->setPalette(p);
+	updateWordCount();
+
 	for (Document* document : std::as_const(m_documents)) {
 		document->loadTheme(theme);
 	}
@@ -612,6 +627,7 @@ void Stack::setHeaderVisible(bool visible)
 		Q_EMIT headerVisible(visible);
 		m_header_visible = header_visible;
 		updateMask();
+		m_top_wordcount->move(15, m_header_visible + 10);
 	}
 }
 
@@ -672,6 +688,7 @@ void Stack::resizeEvent(QResizeEvent* event)
 	updateMask();
 	m_resize_timer->start();
 	updateBackground();
+	m_top_wordcount->move(15, m_header_visible + 10);
 	QWidget::resizeEvent(event);
 }
 
@@ -812,6 +829,18 @@ void Stack::initPrinter()
 	m_printer->setPageSize(QPageSize(QPageSize::Letter));
 	m_printer->setPageOrientation(QPageLayout::Portrait);
 	m_printer->setPageMargins(QMarginsF(1.0, 1.0, 1.0, 1.0), QPageLayout::Inch);
+}
+
+//-----------------------------------------------------------------------------
+
+void Stack::updateWordCount()
+{
+	if (m_current_document) {
+		m_top_wordcount->setText(tr("Words: %L1").arg(m_current_document->wordCount()));
+	} else {
+		m_top_wordcount->setText(tr("Words: %L1").arg(0));
+	}
+	m_top_wordcount->adjustSize();
 }
 
 //-----------------------------------------------------------------------------

--- a/src/stack.h
+++ b/src/stack.h
@@ -11,6 +11,7 @@
 class AlertLayer;
 class Document;
 class FindDialog;
+class QLabel;
 class SceneList;
 class SymbolsDialog;
 class ThemeRenderer;
@@ -107,6 +108,7 @@ public Q_SLOTS:
 	void setHeaderVisible(bool visible);
 	void setScenesVisible(bool visible);
 	void showHeader();
+	void updateWordCount();
 
 protected:
 	void mouseMoveEvent(QMouseEvent* event) override;
@@ -138,6 +140,7 @@ private:
 	QStackedWidget* m_contents;
 	QList<Document*> m_documents;
 	QList<QAction*> m_document_actions;
+	QLabel* m_top_wordcount;
 	Document* m_current_document;
 
 	ThemeRenderer* m_theme_renderer;

--- a/src/stack.h
+++ b/src/stack.h
@@ -126,6 +126,7 @@ private Q_SLOTS:
 
 private:
 	void initPrinter();
+	void positionWordCount();
 
 private:
 	AlertLayer* m_alerts;

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -132,6 +132,7 @@ Theme::ThemeData::ThemeData(const QString& theme_id, bool theme_default, bool cr
 	, paragraph_spacing_below(0, 1000)
 	, tab_width(1, 1000)
 	, show_word_count(false)
+	, wordcount_position(0, 3)
 {
 	if (id.isEmpty() && create) {
 		QString untitled;
@@ -663,6 +664,9 @@ bool Theme::operator==(const Theme& theme) const
 		&& (d->text_font == theme.d->text_font)
 		&& (d->misspelled_color == theme.d->misspelled_color)
 		&& (d->show_word_count == theme.d->show_word_count)
+		&& (d->wordcount_position == theme.d->wordcount_position)
+		&& (d->wordcount_font == theme.d->wordcount_font)
+		&& (d->wordcount_color == theme.d->wordcount_color)
 
 		&& (d->indent_first_line == theme.d->indent_first_line)
 		&& (d->line_spacing == theme.d->line_spacing)
@@ -734,6 +738,9 @@ void Theme::reload()
 	}
 	d->misspelled_color = settings.value("Text/Misspelled", "#ff0000").toString();
 	d->show_word_count = settings.value("Text/ShowWordCount", false).toBool();
+	d->wordcount_position = settings.value("Text/WordcountPosition", 0).toInt();
+	d->wordcount_color = settings.value("Text/WordcountColor", d->text_color.name()).toString();
+	d->wordcount_font.fromString(settings.value("Text/WordcountFont", d->text_font.toString()).toString());
 
 	// Load spacings
 	d->indent_first_line = settings.value("Spacings/IndentFirstLine", false).toBool();
@@ -800,6 +807,9 @@ void Theme::write()
 	settings.setValue("Text/Font", d->text_font.toString());
 	settings.setValue("Text/Misspelled", d->misspelled_color.name());
 	settings.setValue("Text/ShowWordCount", d->show_word_count);
+	settings.setValue("Text/WordcountPosition", d->wordcount_position.value());
+	settings.setValue("Text/WordcountColor", d->wordcount_color.name());
+	settings.setValue("Text/WordcountFont", d->wordcount_font.toString());
 
 	// Store spacings
 	settings.setValue("Spacings/IndentFirstLine", d->indent_first_line);

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -131,6 +131,7 @@ Theme::ThemeData::ThemeData(const QString& theme_id, bool theme_default, bool cr
 	, paragraph_spacing_above(0, 1000)
 	, paragraph_spacing_below(0, 1000)
 	, tab_width(1, 1000)
+	, show_word_count(false)
 {
 	if (id.isEmpty() && create) {
 		QString untitled;
@@ -661,6 +662,7 @@ bool Theme::operator==(const Theme& theme) const
 		&& (d->text_color == theme.d->text_color)
 		&& (d->text_font == theme.d->text_font)
 		&& (d->misspelled_color == theme.d->misspelled_color)
+		&& (d->show_word_count == theme.d->show_word_count)
 
 		&& (d->indent_first_line == theme.d->indent_first_line)
 		&& (d->line_spacing == theme.d->line_spacing)
@@ -731,6 +733,7 @@ void Theme::reload()
 		d->text_font.setPointSize(std::max(point_size, QFont().pointSize()));
 	}
 	d->misspelled_color = settings.value("Text/Misspelled", "#ff0000").toString();
+	d->show_word_count = settings.value("Text/ShowWordCount", false).toBool();
 
 	// Load spacings
 	d->indent_first_line = settings.value("Spacings/IndentFirstLine", false).toBool();
@@ -796,6 +799,7 @@ void Theme::write()
 	settings.setValue("Text/Color", d->text_color.name());
 	settings.setValue("Text/Font", d->text_font.toString());
 	settings.setValue("Text/Misspelled", d->misspelled_color.name());
+	settings.setValue("Text/ShowWordCount", d->show_word_count);
 
 	// Store spacings
 	settings.setValue("Spacings/IndentFirstLine", d->indent_first_line);

--- a/src/theme.h
+++ b/src/theme.h
@@ -61,6 +61,9 @@ class Theme : public SettingsFile
 		QFont text_font;
 		QColor misspelled_color;
 		bool show_word_count;
+		RangedInt wordcount_position;
+		QFont wordcount_font;
+		QColor wordcount_color;
 
 		bool indent_first_line;
 		RangedInt line_spacing;
@@ -155,11 +158,17 @@ public:
 	QFont textFont() const { return d->text_font; }
 	QColor misspelledColor() const { return d->misspelled_color; }
 	bool showWordCount() const { return d->show_word_count; }
+	RangedInt wordcountPosition() const { return d->wordcount_position; }
+	QFont wordcountFont() const { return d->wordcount_font; }
+	QColor wordcountColor() const { return d->wordcount_color; }
 
 	void setTextColor(const QColor& color) { setValue(d->text_color, color); }
 	void setTextFont(const QFont& font) { setValue(d->text_font, font); }
 	void setMisspelledColor(const QColor& color) { setValue(d->misspelled_color, color); }
 	void setShowWordCount(bool show) { setValue(d->show_word_count, show); }
+	void setWordcountPosition(int position) { setValue(d->wordcount_position, position); }
+	void setWordcountFont(const QFont& font) { setValue(d->wordcount_font, font); }
+	void setWordcountColor(const QColor& color) { setValue(d->wordcount_color, color); }
 
 	// Spacing settings
 	bool indentFirstLine() const { return d->indent_first_line; }

--- a/src/theme.h
+++ b/src/theme.h
@@ -60,6 +60,7 @@ class Theme : public SettingsFile
 		QColor text_color;
 		QFont text_font;
 		QColor misspelled_color;
+		bool show_word_count;
 
 		bool indent_first_line;
 		RangedInt line_spacing;
@@ -153,10 +154,12 @@ public:
 	QColor textColor() const { return d->text_color; }
 	QFont textFont() const { return d->text_font; }
 	QColor misspelledColor() const { return d->misspelled_color; }
+	bool showWordCount() const { return d->show_word_count; }
 
 	void setTextColor(const QColor& color) { setValue(d->text_color, color); }
 	void setTextFont(const QFont& font) { setValue(d->text_font, font); }
 	void setMisspelledColor(const QColor& color) { setValue(d->misspelled_color, color); }
+	void setShowWordCount(bool show) { setValue(d->show_word_count, show); }
 
 	// Spacing settings
 	bool indentFirstLine() const { return d->indent_first_line; }

--- a/src/theme_dialog.cpp
+++ b/src/theme_dialog.cpp
@@ -92,11 +92,16 @@ ThemeDialog::ThemeDialog(Theme& theme, QWidget* parent)
 	font_layout->addWidget(m_font_names);
 	font_layout->addWidget(m_font_sizes);
 
+	m_show_word_count = new QCheckBox(tr("Show word count in top left"), text_group);
+	m_show_word_count->setChecked(m_theme.showWordCount());
+	connect(m_show_word_count, &QCheckBox::toggled, this, &ThemeDialog::renderPreview);
+
 	QFormLayout* text_layout = new QFormLayout(text_group);
 	text_layout->setFieldGrowthPolicy(QFormLayout::FieldsStayAtSizeHint);
 	text_layout->addRow(tr("Color:"), m_text_color);
 	text_layout->addRow(tr("Font:"), font_layout);
 	text_layout->addRow(tr("Misspelled:"), m_misspelled_color);
+	text_layout->addRow(QString(), m_show_word_count);
 
 
 	// Create background group
@@ -552,6 +557,7 @@ void ThemeDialog::setValues(Theme& theme)
 	font.setPointSizeF(m_font_sizes->currentText().toDouble());
 	theme.setTextFont(font);
 	theme.setMisspelledColor(m_misspelled_color->color());
+	theme.setShowWordCount(m_show_word_count->isChecked());
 
 	theme.setIndentFirstLine(m_indent_first_line->isChecked());
 	theme.setLineSpacing(m_line_spacing->value());

--- a/src/theme_dialog.cpp
+++ b/src/theme_dialog.cpp
@@ -92,16 +92,48 @@ ThemeDialog::ThemeDialog(Theme& theme, QWidget* parent)
 	font_layout->addWidget(m_font_names);
 	font_layout->addWidget(m_font_sizes);
 
-	m_show_word_count = new QCheckBox(tr("Show word count in top left"), text_group);
-	m_show_word_count->setChecked(m_theme.showWordCount());
-	connect(m_show_word_count, &QCheckBox::toggled, this, &ThemeDialog::renderPreview);
-
 	QFormLayout* text_layout = new QFormLayout(text_group);
 	text_layout->setFieldGrowthPolicy(QFormLayout::FieldsStayAtSizeHint);
 	text_layout->addRow(tr("Color:"), m_text_color);
 	text_layout->addRow(tr("Font:"), font_layout);
 	text_layout->addRow(tr("Misspelled:"), m_misspelled_color);
-	text_layout->addRow(QString(), m_show_word_count);
+
+	m_wordcount_group = new QGroupBox(tr("Corner Word Count"), contents);
+	m_wordcount_group->setCheckable(true);
+	m_wordcount_group->setChecked(m_theme.showWordCount());
+	connect(m_wordcount_group, &QGroupBox::clicked, this, &ThemeDialog::renderPreview);
+
+	m_wordcount_position = new QComboBox(m_wordcount_group);
+	m_wordcount_position->addItems({ tr("Top Left"), tr("Top Right"), tr("Bottom Left"), tr("Bottom Right") });
+	m_wordcount_position->setCurrentIndex(m_theme.wordcountPosition());
+	connect(m_wordcount_position, &QComboBox::currentIndexChanged, this, &ThemeDialog::renderPreview);
+
+	m_wordcount_color = new ColorButton(m_wordcount_group);
+	m_wordcount_color->setColor(m_theme.wordcountColor());
+	connect(m_wordcount_color, &ColorButton::changed, this, &ThemeDialog::renderPreview);
+
+	m_wordcount_font_names = new QFontComboBox(m_wordcount_group);
+	m_wordcount_font_names->setEditable(false);
+	m_wordcount_font_names->setCurrentFont(m_theme.wordcountFont());
+	connect(m_wordcount_font_names, &QComboBox::activated, this, &ThemeDialog::wordcountFontChanged);
+	connect(m_wordcount_font_names, &QComboBox::activated, this, &ThemeDialog::renderPreview);
+
+	m_wordcount_font_sizes = new QComboBox(m_wordcount_group);
+	m_wordcount_font_sizes->setEditable(true);
+	m_wordcount_font_sizes->setMinimumContentsLength(3);
+	connect(m_wordcount_font_sizes, &QComboBox::editTextChanged, this, &ThemeDialog::renderPreview);
+
+	QHBoxLayout* wordcount_font_layout = new QHBoxLayout;
+	wordcount_font_layout->addWidget(m_wordcount_font_names);
+	wordcount_font_layout->addWidget(m_wordcount_font_sizes);
+
+	QFormLayout* wordcount_layout = new QFormLayout(m_wordcount_group);
+	wordcount_layout->setFieldGrowthPolicy(QFormLayout::FieldsStayAtSizeHint);
+	wordcount_layout->addRow(tr("Position:"), m_wordcount_position);
+	wordcount_layout->addRow(tr("Color:"), m_wordcount_color);
+	wordcount_layout->addRow(tr("Font:"), wordcount_font_layout);
+
+	wordcountFontChanged();
 
 
 	// Create background group
@@ -346,6 +378,7 @@ ThemeDialog::ThemeDialog(Theme& theme, QWidget* parent)
 
 	QVBoxLayout* groups_layout = new QVBoxLayout(contents);
 	groups_layout->addWidget(text_group);
+	groups_layout->addWidget(m_wordcount_group);
 	groups_layout->addWidget(background_group);
 	groups_layout->addWidget(foreground_group);
 	groups_layout->addWidget(m_round_corners);
@@ -437,6 +470,36 @@ void ThemeDialog::fontChanged()
 	m_font_sizes->setEditText(QString::number(font_size));
 	m_font_sizes->setValidator(new QDoubleValidator(font_sizes.constFirst(), font_sizes.constLast(), 1, m_font_sizes));
 	m_font_sizes->blockSignals(false);
+}
+
+//-----------------------------------------------------------------------------
+
+void ThemeDialog::wordcountFontChanged()
+{
+	const QFont font = m_wordcount_font_names->currentFont();
+	QList<int> font_sizes = QFontDatabase::smoothSizes(font.family(), QString());
+	if (font_sizes.isEmpty()) {
+		font_sizes = QFontDatabase::standardSizes();
+	}
+	qreal font_size = m_wordcount_font_sizes->currentText().toDouble();
+	if (font_size < 0.1) {
+		font_size = std::lround(m_theme.wordcountFont().pointSizeF() * 10.0) * 0.1;
+	}
+
+	m_wordcount_font_sizes->blockSignals(true);
+	m_wordcount_font_sizes->clear();
+	int index = 0;
+	for (int i = 0, count = font_sizes.count(); i < count; ++i) {
+		const int size = font_sizes.at(i);
+		if (size <= font_size) {
+			index = i;
+		}
+		m_wordcount_font_sizes->addItem(QString::number(size));
+	}
+	m_wordcount_font_sizes->setCurrentIndex(index);
+	m_wordcount_font_sizes->setEditText(QString::number(font_size));
+	m_wordcount_font_sizes->setValidator(new QDoubleValidator(font_sizes.constFirst(), font_sizes.constLast(), 1, m_wordcount_font_sizes));
+	m_wordcount_font_sizes->blockSignals(false);
 }
 
 //-----------------------------------------------------------------------------
@@ -557,7 +620,13 @@ void ThemeDialog::setValues(Theme& theme)
 	font.setPointSizeF(m_font_sizes->currentText().toDouble());
 	theme.setTextFont(font);
 	theme.setMisspelledColor(m_misspelled_color->color());
-	theme.setShowWordCount(m_show_word_count->isChecked());
+
+	theme.setShowWordCount(m_wordcount_group->isChecked());
+	theme.setWordcountPosition(m_wordcount_position->currentIndex());
+	theme.setWordcountColor(m_wordcount_color->color());
+	QFont wordcount_font = m_wordcount_font_names->currentFont();
+	wordcount_font.setPointSizeF(m_wordcount_font_sizes->currentText().toDouble());
+	theme.setWordcountFont(wordcount_font);
 
 	theme.setIndentFirstLine(m_indent_first_line->isChecked());
 	theme.setLineSpacing(m_line_spacing->value());

--- a/src/theme_dialog.h
+++ b/src/theme_dialog.h
@@ -40,6 +40,7 @@ protected:
 private Q_SLOTS:
 	void checkNameAvailable();
 	void fontChanged();
+	void wordcountFontChanged();
 	void imageChanged();
 	void lineSpacingChanged(int index);
 	void positionChanged(int index);
@@ -97,7 +98,11 @@ private:
 	QSpinBox* m_spacing_above_paragraph;
 	QSpinBox* m_spacing_below_paragraph;
 	QCheckBox* m_indent_first_line;
-	QCheckBox* m_show_word_count;
+	QGroupBox* m_wordcount_group;
+	QComboBox* m_wordcount_position;
+	ColorButton* m_wordcount_color;
+	QFontComboBox* m_wordcount_font_names;
+	QComboBox* m_wordcount_font_sizes;
 };
 
 #endif // FOCUSWRITER_THEME_DIALOG_H

--- a/src/theme_dialog.h
+++ b/src/theme_dialog.h
@@ -97,6 +97,7 @@ private:
 	QSpinBox* m_spacing_above_paragraph;
 	QSpinBox* m_spacing_below_paragraph;
 	QCheckBox* m_indent_first_line;
+	QCheckBox* m_show_word_count;
 };
 
 #endif // FOCUSWRITER_THEME_DIALOG_H


### PR DESCRIPTION
This is a small update to the theme editor to allow the inclusion of the word count into the theme. I normally use the Sway Desktop environment on Ubuntu Linux (although this screenshot is from GNOME),  and I really like the editor experience overall, but it was a bit of a bother to see the word count of the file, since it normally only appears in the bottom toolbar.  In Sway and GNOME, the bottom toolbar takes up a lot of vertical space, so I wanted something a bit more subtle.

This allows themes to display the word count in one of the corners, with whatever font family, color, and size the the user wants to set it to.

<img width="647" height="477" alt="Screenshot From 2026-06-22 22-17-40" src="https://github.com/user-attachments/assets/7734c4a1-76a3-4675-aaf1-cdf89ff23703" />
 
<img width="1825" height="901" alt="Screenshot From 2026-06-22 22-07-57" src="https://github.com/user-attachments/assets/461acc14-5862-4f13-9257-2a1449e9ee34" />

